### PR TITLE
✏️ Fix typos in CAM_PER output inversion

### DIFF
--- a/Nouveau PIR/firmware/source/main.c
+++ b/Nouveau PIR/firmware/source/main.c
@@ -708,9 +708,6 @@ void __attribute__((__interrupt__, no_auto_psv)) TIM7_IRQHandler(void)
         {
         case 1: { // failure for the falling edge
             GPIO_ResetBits(GPIOG, 6);
-
-            GPIO_ResetBits(GPIOG, 6);
-
             if (failure_waiting == true)
             {                              // if the rising edge has already happen
                 if (sensortype_CRK == 'c') // sensor is cpdd

--- a/Nouveau PIR/firmware/source/main.c
+++ b/Nouveau PIR/firmware/source/main.c
@@ -612,7 +612,7 @@ void __attribute__((__interrupt__, no_auto_psv)) TIM6_IRQHandler(void)
 
         if (GPIO_ReadInputDataBit(GPIOG, 7) == 1)
         {
-            GPIO_SetBits(GPIOG, 7);
+            GPIO_ResetBits(GPIOG, 7);
         }
         else
         {
@@ -642,7 +642,7 @@ void __attribute__((__interrupt__, no_auto_psv)) TIM6_IRQHandler(void)
 
         if (GPIO_ReadInputDataBit(GPIOG, 6) == 1)
         {
-            GPIO_SetBits(GPIOG, 6);
+            GPIO_ResetBits(GPIOG, 6);
         }
         else
         {
@@ -670,7 +670,7 @@ void __attribute__((__interrupt__, no_auto_psv)) TIM7_IRQHandler(void)
     {
         if (GPIO_ReadInputDataBit(GPIOG, 8) == 1)
         {
-            GPIO_SetBits(GPIOG, 8);
+            GPIO_ResetBits(GPIOG, 8);
         }
         else
         {
@@ -691,7 +691,7 @@ void __attribute__((__interrupt__, no_auto_psv)) TIM7_IRQHandler(void)
     {
         if (GPIO_ReadInputDataBit(GPIOG, 6) == 1)
         {
-            GPIO_SetBits(GPIOG, 6);
+            GPIO_ResetBits(GPIOG, 6);
         }
         else
         {


### PR DESCRIPTION
Unless I'm mistaken, you were doing the same thing in the if and in the else.

While the purpose I think was to invert the output.